### PR TITLE
Prevent b3s23osc_stdin from getting stuck

### DIFF
--- a/oscillators.txt
+++ b/oscillators.txt
@@ -8065,7 +8065,7 @@ $27b3o$44b2o$45bo$3b2o10b2o6b2o20bob2o$4bo9bobo6bo13b2o4b3o2bo$2bo13bo
 obo12b3o$3bo15b2obobo2bo13bo$3b4o15bo2b3o14b5o$b2o3bo3b2o10b3o7bo13bo$
 o2b3o4b2o13bo6bobo9bo$2obo20b2o6b2o10b2o$3bo$3b2o$19b3o$19bo$11b2o7bo$
 12bo$9b3o22b2o$9bo17b2o5bobo$27b2o7bo$36b2o2$23bo$22bobob2o$22bobobobo
-$19b2obobobobo2bo$19bo2bo2b2ob4o$21b2o4bo$27bobo$28b2o
+$19b2obobobobo2bo$19bo2bo2b2ob4o$21b2o4bo$27bobo$28b2o!
 
 #N Two p18 LOM sparkers hassling loaf
 #O DER 10/14/21


### PR DESCRIPTION
In the RLE of the p54 Snark loop (xp54_ydo8bp6o8g0s4gozy7ggy31230343zy8346y1gcgy9ok46zxggyc33ggyf4s0ggzw64lkk8y7g0s4laieg8ow66522y1mlld221zok4raa6y144a66w11074lq23y9122qi6zx32y2ggy9scgzy56221ya3y262sgzyfgg0s2s0s4owgzyf1023w1169d11) in oscillators.txt, an exclamation point is missing at the end of the RLE. This doesn't only cause consistency issues, but when I put the collection into stdin symmetry (b3s23osc_stdin), it gets stuck and never progresses beyond xp54_178cy6gy6c871y0178cy6gy6c871zy433xn31y688k8888k88y613nx33z0g8oy033x372y5o8gy2g8oy5273x33y0o8gz23yl32y023yl32, the oscillator preceding the problematic RLE, forcing me to interrupt the apgsearch instance and try again.

While I can manually correct the RLE each time I refresh my local copy to get the oscillators up-to-date, doing so doesn't fix the underlying issue in the repository. I hope you will accept the merge request and get the exclamation point back to the problematic RLE.